### PR TITLE
Script to copy template sheet

### DIFF
--- a/spotnik/copy_sheet.py
+++ b/spotnik/copy_sheet.py
@@ -1,0 +1,31 @@
+import argparse
+import pygsheets  # pip3 install pygsheets
+
+
+SHEET_URL = "https://docs.google.com/spreadsheets/d/1z5MejG6EKg8rf8vYKeFhw9XT_3PxkDFOrPSEKT_jYqI/edit#gid=1936655481"
+SHEET_TITLE = "Spotify Controller"
+
+
+def copy_sheet(service_file, gmail):
+	gc = pygsheets.authorize(service_file=service_file)
+
+	template_sh = gc.open_by_url(SHEET_URL)
+	copied_sh = gc.create(title=SHEET_TITLE, template=template_sh)
+
+	# optionally remove "validation" worksheet
+	val_wks = [wks for wks in copied_sh.worksheets() if wks.title == "validation"]
+	if (val_wks):
+	    copied_sh.del_worksheet(val_wks[0])
+
+	copied_sh.share(gmail)
+	print('shared sheet "%s" to %s' % (SHEET_TITLE, gmail))
+	return
+
+
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser(description='copy sheet')
+	parser.add_argument('service_file', type=str, help='path to auth service file')
+	parser.add_argument('gmail', type=str, help='gmail to share to')
+	args = parser.parse_args()
+
+	copy_sheet(args.service_file, args.gmail)


### PR DESCRIPTION
Re riverscuomo/spotkin#13

Tiny script to copy the template sheet to a user-specified gmail.
The function can be imported:

```
from copy_sheet import copy_sheet
copy_sheet("/path/to/credentials.json", "myemail@gmail.com")
```

Or ran standalone:

```
python3 copy_sheet.py "/path/to/credentials.json" "myemail@gmail.com"
```

TLDR: fetches the template sheet from your URL,
duplicates it, optionally deletes the "validation" sheet,
and shares the duplicated sheet to a gmail.

Pulls in [pygsheets](https://github.com/nithinmurali/pygsheets) as a dependency, but it does the job in 4 lines.
pygsheets uses the same Google authorization backend as gspread
(service_file should equal GSPREADER_GOOGLE_CREDS_PATH),
so the transition shouldn't be too hard.

Let me know of any issues.