### PR TITLE
Refactor import statements to use relative imports

### DIFF
--- a/spotkin/__main__.py
+++ b/spotkin/__main__.py
@@ -2,18 +2,12 @@ from datetime import datetime
 from re import X
 from time import sleep
 
-try:
-    from scripts.process_job import process_job
-    from scripts.bans import *
-    from scripts.post_description import *
-    from scripts.api import *
-    from scripts.utils import *
-except:
-    from spotkin.scripts.process_job import process_job
-    from spotkin.scripts.bans import *
-    from spotkin.scripts.post_description import *
-    from spotkin.scripts.api import *
-    from spotkin.scripts.utils import *
+from .scripts.process_job import process_job
+from .scripts.bans import *
+from .scripts.post_description import *
+from .scripts.api import *
+from .scripts.utils import *
+
 from dotenv import load_dotenv
 import gspreader
 import gspread


### PR DESCRIPTION
Fixes #23 

Refactor import statements in the `__main__.py` file to use relative imports instead of a try-except block.

# Before

```python
try:
    from scripts.process_job import process_job
    from scripts.bans import *
    from scripts.post_description import *
    from scripts.api import *
    from scripts.utils import *
except:
    from spotkin.scripts.process_job import process_job
    from spotkin.scripts.bans import *
    from spotkin.scripts.post_description import *
    from spotkin.scripts.api import *
    from spotkin.scripts.utils import *
```

# After

```python
from .scripts.process_job import process_job
from .scripts.bans import *
from .scripts.post_description import *
from .scripts.api import *
from .scripts.utils import *
```