### PR TITLE
Fix misspelled/mismatched environment variable names

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ CORS(app)
 app.secret_key = os.getenv('SECRET_KEY', 'supersecretkey')
 
 client_id = os.getenv('SPOTIFY_CLIENT_ID')
-client_secret = os.getenv('SPOTIPY_CLIENT_SECRET')
+client_secret = os.getenv('SPOTIFY_CLIENT_SECRET')
 redirect_uri = os.getenv('SPOTIFY_REDIRECT_URI')
 
 

--- a/spotkin/scripts/api.py
+++ b/spotkin/scripts/api.py
@@ -20,8 +20,8 @@ load_dotenv()
 def get_spotify_client(refresh_token: str = None, timeout: int = 20) -> Spotify:
     log("[get_spotify] Creating Spotify client")
     CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
-    CLIENT_SECRET = os.getenv("SPOTIPY_CLIENT_SECRET")
-    SPOTIPY_REDIRECT_URL = os.getenv("SPOTIPY_REDIRECT_URL")
+    CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
+    SPOTIPY_REDIRECT_URL = os.getenv("SPOTIFY_REDIRECT_URL")
     SPOTIFY_SCOPE = "playlist-modify-private, playlist-modify-public, user-library-read, playlist-read-private, user-library-modify, user-read-recently-played"
 
     print(SPOTIPY_REDIRECT_URL)


### PR DESCRIPTION
Fixes #25 

Fix misspelling of environment variable names in the source code, or mismatch with the names in the `README.md` instructions.

# Before 

At line 20 in `spotkin.py`:

```
client_secret = os.getenv('SPOTIPY_CLIENT_SECRET')`
```

At lines 23 and 24 in `scripts/api.py`

```
CLIENT_SECRET = os.getenv("SPOTIPY_CLIENT_SECRET")
SPOTIPY_REDIRECT_URL = os.getenv("SPOTIPY_REDIRECT_URL")
```

# After

At line 20 in `spotkin.py`:

```
client_secret = os.getenv('SPOTIFY_CLIENT_SECRET')`
```

At lines 23 and 24 in `scripts/api.py`

```
CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
SPOTIPY_REDIRECT_URL = os.getenv("SPOTIFY_REDIRECT_URL")
```