### PR TITLE
Fix 'banned genres' filtering not working

### DIFF
--- a/spotkin/scripts/process_job.py
+++ b/spotkin/scripts/process_job.py
@@ -43,7 +43,7 @@ def process_job(spotify, job):
         artist_id = track["artists"][0]["id"]
         artist_name = track["artists"][0]["name"]
         artist_genre = next(
-            (x for x in artists_genres if x["artist_id"] == artist_id), None
+            (x['genres'] for x in artists_genres if x["artist_id"] == artist_id and "genres" in x), None
         )
 
         if playlist_filter.is_banned(artist_genre, artist_name, track_name, track_id, track):


### PR DESCRIPTION
hi,
this PR should resolve this issue: https://github.com/riverscuomo/spotkin_flutter/issues/58

the issue seemed to occur because of a type mismatch between the `_is_banned_by_genre` method (that expects a list of genres to be passed as parameter), and the variable that extracts the genres from all the artists, that instead of containing a list of genres contained a list of Artists:
```python
        artist_genre = next(
            (x for x in artists_genres if x["artist_id"] == artist_id), None
        )
```


I have patched this issue by extracting the genres directly instead:
```python
        artist_genre = next(
            (x['genres'] for x in artists_genres if x["artist_id"] == artist_id and "genres" in x), None
        )
```

thanks.